### PR TITLE
fix: stats-row block settings now apply to both cards correctly

### DIFF
--- a/components/builder/config/block-config-fields.tsx
+++ b/components/builder/config/block-config-fields.tsx
@@ -151,10 +151,13 @@ export function BlockConfigFields({
 
   switch (type) {
     case 'stats-row': {
-      const statsChildren =
-        block.children?.filter((child): child is Block & { type: StatsChildType } =>
-          statsChildTypes.includes(child.type as StatsChildType),
-        ) ?? [];
+      const statsChildren = block.children
+        ? [
+            ...block.children.filter((child): child is Block & { type: StatsChildType } =>
+              statsChildTypes.includes(child.type as StatsChildType),
+            ),
+          ]
+        : [];
 
       const updateCardProps = (slotIndex: 0 | 1, updates: Record<string, unknown>) => {
         const nextSlots: Array<Block | undefined> = [statsChildren[0], statsChildren[1]];


### PR DESCRIPTION
## Description

<!-- Describe your changes and motivation -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Testing

<!-- Describe testing performed -->

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Linked to related issue (if applicable)

## Screenshots (if applicable)
